### PR TITLE
Fix to avoid error code 150 No status provided

### DIFF
--- a/lib/testlinkapi.js
+++ b/lib/testlinkapi.js
@@ -809,7 +809,13 @@ TestLinkApi.prototype.reportTCResult = function(params, callback) {
         bugid: {
             value: params.bugid || "bugid",
             type: "string"
-        }
+        },
+        // added to avoid error:
+        //  { struct: { code: '150', message: 'No status provided.' } }
+        status: {
+            value: params.status || 'status',
+            type: 'string'
+        },
     },
 		body = utilites.getRequestByObject(inputObject);
     utilites.postRequest(post, body, function(response) {


### PR DESCRIPTION
Getting error `{ struct: { code: '150', message: 'No status provided.' } }`
This fixes it.