### PR TITLE
Add status to reportTCResult function

### DIFF
--- a/lib/testlinkapi.js
+++ b/lib/testlinkapi.js
@@ -794,6 +794,10 @@ TestLinkApi.prototype.reportTCResult = function(params, callback) {
             value: params.buildid || "buildid",
             type: "string"
         },
+        status: {
+       	    value: params.status || "status",
+            type: "string"
+        },
         notes: {
             value: params.notes || "notes",
             type: "string"


### PR DESCRIPTION
Reporting to testlink always gives "No status provided." This would fix that.